### PR TITLE
add high_stress segment classification to API

### DIFF
--- a/app/app/main.py
+++ b/app/app/main.py
@@ -46,6 +46,10 @@ async def get_lowest_stress_route(
             seq,
             edge as id,
             b.len_feet,
+            case 
+			    when linklts >= 3 then 'true' 
+				else 'false' 
+			end as high_stress,
             b.geom as geometry
         from
             pgr_dijkstra(


### PR DESCRIPTION
satisfying request: 'Regarding the high stress lines, yes, if you could output something like “high_stress”: true or “high_stress”:false to the API for every item (feature) in the API where the line segment has an LTS of 3 or 4, that would be great.  (For the existing version we were saying LTS 3 and 4 were high stress but if you want it to just be 4 that’s fine too.' from Corey Acri, June 2022